### PR TITLE
Hive Fixes

### DIFF
--- a/playbooks/roles/mapr-hive/tasks/main.yml
+++ b/playbooks/roles/mapr-hive/tasks/main.yml
@@ -47,7 +47,6 @@
     password="{{hive_db_pass}}"
     check_implicit_admin=yes
     priv={{hive_db}}.*:ALL
-    check_implicit_admin=yes
     login_user="{{mysql_root_user}}"
     login_password="{{mysql_root_password}}"
     login_host="{{hive_metastore_host}}"
@@ -59,7 +58,6 @@
     password={{hive_db_pass}}
     check_implicit_admin=yes
     priv={{hive_db}}.*:ALL
-    check_implicit_admin=yes
     login_user="{{mysql_root_user}}"
     login_password="{{mysql_root_password}}"
     login_host="{{hive_metastore_host}}"

--- a/playbooks/roles/mapr-hive/vars/main.yml
+++ b/playbooks/roles/mapr-hive/vars/main.yml
@@ -3,5 +3,5 @@
 hive_db: metastore
 hive_db_user: hive
 hive_db_pass: mapr
-hive_db_host: "{{groups['mysql'] | first}}"
+hive_db_host: "{{groups['hiveserver'] | first}}"
 hive_metastore_host: "{{ hostvars[hive_db_host].ansible_default_ipv4.address }}"


### PR DESCRIPTION
Fixed duplicate `check_implicit_admin=yes` in create mapr user@loaclhost and create mapr user@%

changed `groups['mysql']` to `groups['hiveserver']` in `playbooks/roles/mapr-aws-bootstrap/tasks/main.yml`
