### PR TITLE
updates to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,7 @@ Vagrant.configure("2") do |config|
     node1.vm.network :forwarded_port, guest: 8443, host: 8443
     node1.vm.network :forwarded_port, guest: 8000, host: 8000
     node1.vm.network :forwarded_port, guest: 10000, host: 10000
-    #node1.vm.network :private_network, type: "dhcp"
-    node1.vm.network :private_network, :ip =>'192.168.59.0', :auto_network => true, :type => "dhcp" 
+    node1.vm.network :private_network, :ip =>'192.168.99.0', :auto_network => true, :type => "dhcp" 
 
     node1.vm.provider :virtualbox do |provider|
       provider.name = "mapr_singlenode"
@@ -39,8 +38,12 @@ Vagrant.configure("2") do |config|
     ansible.inventory_path = 'hosts'
     ansible.host_key_checking = false
     #ansible.verbose = "vvvv" 
+    ansible.sudo = true
     ansible.extra_vars = {
-      mapr_disks: [ "/dev/sdb","/dev/sdc","/dev/sdd","/dev/sde" ]
+      mapr_disks: [ "/dev/sdb","/dev/sdc","/dev/sdd","/dev/sde" ],
+      mapr_cluster_name: 'vagrant',
+      single_node_cluster: true,
+      #secure_cluster: False
     }
     ansible.playbook = "playbooks/install_cluster.yml"
   end

--- a/playbooks/authorized_keys.yml
+++ b/playbooks/authorized_keys.yml
@@ -22,6 +22,7 @@
         - "/tmp/root*id_dsa.pub"
 
 - hosts: localhost
+  sudo: no
   tasks:
     - name: clean up the public keys we copied to the local machine in the last play
       file: state=absent path={{item}}

--- a/playbooks/install_cluster.yml
+++ b/playbooks/install_cluster.yml
@@ -143,3 +143,11 @@
     - name: print webserver URLs
       debug: msg="webserver=https://{{ansible_eth1.ipv4.address}}:8443"
       when: "ec2_facts is not defined"
+
+
+- hosts: cldb[0]
+  sudo: yes
+  tasks:
+    - name: set replication to 1 if single node
+      shell: maprcli volume list -columns volumename | grep -v volumename | awk '{print $1}' | xargs -n1 -I'{}' maprcli volume modify -name '{}' -replication 1 -minreplication 1
+      when: single_node_cluster is defined and single_node_cluster == True

--- a/playbooks/roles/zookeeper/tasks/main.yml
+++ b/playbooks/roles/zookeeper/tasks/main.yml
@@ -1,6 +1,3 @@
-- name: open port 5181 for zookeeper
-  command: iptables -I INPUT -m state --state NEW -m tcp -p tcp --dport 5181 -j ACCEPT
-
 - name: install mapr-zookeeper
   yum: name='{{item}}' state=present
   with_items:


### PR DESCRIPTION
- set cluster name to vagrant
- set variable single_node_cluster to signal that replication should be
  set to 1 on all volumes
- add shell command in install_cluster to set replication to 1
- moved host only network to 192.168.99 to avoid a conflict on my
  laptop. hopefully does not cause anyone else problems.
- removed firewall port stuff from zookeeper install. Assume we're
  uninstalling the firewall. Anyways, firewall management should probably
  go elsewhere.
